### PR TITLE
Feature/set bitrate

### DIFF
--- a/src/ios/OpenTokPlugin.h
+++ b/src/ios/OpenTokPlugin.h
@@ -45,3 +45,10 @@
 - (void)TBTesting:(CDVInvokedUrlCommand*)command;
 
 @end
+
+@interface OTPublisherKit(AudioBitrate)
+
+// Audio Bitrate
+- (void)setMaxAudioBitrateKbps:(int)maxAudioKbits;
+
+@end

--- a/src/ios/OpenTokPlugin.m
+++ b/src/ios/OpenTokPlugin.m
@@ -86,8 +86,11 @@
         bpubVideo = NO;
     }
 
+    int maxAudioBitrate = [[command.arguments objectAtIndex:11] intValue];
+
     // Publish and set View
     _publisher = [[OTPublisher alloc] initWithDelegate:self name:name];
+    [_publisher setMaxAudioBitrateKbps:maxAudioBitrate];
     [_publisher setPublishAudio:bpubAudio];
     [_publisher setPublishVideo:bpubVideo];
     [self.webView.superview addSubview:_publisher.view];

--- a/src/js/OTPublisher.coffee
+++ b/src/js/OTPublisher.coffee
@@ -4,7 +4,7 @@
 #     stream - The Stream object corresponding to the stream of the publisher
 #     session (Session) — The Session to which the Publisher is publishing a stream. If the Publisher is not publishing a stream to a Session, this property is set to null.
 #     replaceElementId (String) — The ID of the DOM element that was replaced when the Publisher video stream was inserted.
-#   Methods: 
+#   Methods:
 #     destroy():Publisher - not yet implemented
 #     getImgData() : String - not yet implemented
 #     getStyle() : Object - not yet implemented
@@ -25,12 +25,14 @@ class TBPublisher
     cameraName = "front"
     zIndex = TBGetZIndex(document.getElementById(@domId))
     ratios = TBGetScreenRatios()
+    maxAudioBitrate = "40"
 
     if @properties?
       width = @properties.width ? position.width
       height = @properties.height ? position.height
       name = @properties.name ? ""
       cameraName = @properties.cameraName ? "front"
+      maxAudioBitrate = @properties.maxAudioBitrate ? maxAudioBitrate
       if(@properties.publishAudio? and @properties.publishAudio==false)
         publishAudio="false"
       if(@properties.publishVideo? and @properties.publishVideo==false)
@@ -43,7 +45,7 @@ class TBPublisher
     position = getPosition(@domId)
     TBUpdateObjects()
     OT.getHelper().eventing(@)
-    Cordova.exec(TBSuccess, TBError, OTPlugin, "initPublisher", [name, position.top, position.left, width, height, zIndex, publishAudio, publishVideo, cameraName, ratios.widthRatio, ratios.heightRatio] )
+    Cordova.exec(TBSuccess, TBError, OTPlugin, "initPublisher", [name, position.top, position.left, width, height, zIndex, publishAudio, publishVideo, cameraName, ratios.widthRatio, ratios.heightRatio, maxAudioBitrate] )
     Cordova.exec(@eventReceived, TBSuccess, OTPlugin, "addEvent", ["publisherEvents"] )
   setSession: (session) =>
     @session = session

--- a/src/js/OTPublisher.coffee
+++ b/src/js/OTPublisher.coffee
@@ -25,14 +25,14 @@ class TBPublisher
     cameraName = "front"
     zIndex = TBGetZIndex(document.getElementById(@domId))
     ratios = TBGetScreenRatios()
-    maxAudioBitrate = "40"
+    defaultAudioBitrate = "40"
 
     if @properties?
       width = @properties.width ? position.width
       height = @properties.height ? position.height
       name = @properties.name ? ""
       cameraName = @properties.cameraName ? "front"
-      maxAudioBitrate = @properties.maxAudioBitrate ? maxAudioBitrate
+      maxAudioBitrate = @properties.maxAudioBitrate ? defaultAudioBitrate
       if(@properties.publishAudio? and @properties.publishAudio==false)
         publishAudio="false"
       if(@properties.publishVideo? and @properties.publishVideo==false)

--- a/www/opentok.js
+++ b/www/opentok.js
@@ -281,7 +281,7 @@ TBPublisher = (function() {
     this.streamCreated = __bind(this.streamCreated, this);
     this.eventReceived = __bind(this.eventReceived, this);
     this.setSession = __bind(this.setSession, this);
-    var cameraName, height, name, position, publishAudio, publishVideo, ratios, width, zIndex, _ref, _ref1, _ref2, _ref3;
+    var cameraName, height, name, position, publishAudio, publishVideo, ratios, width, zIndex, _ref, _ref1, _ref2, _ref3, maxAudioBitrate;
     this.sanitizeInputs(one, two, three);
     pdebug("creating publisher", {});
     position = getPosition(this.domId);
@@ -302,6 +302,7 @@ TBPublisher = (function() {
       if ((this.properties.publishVideo != null) && this.properties.publishVideo === false) {
         publishVideo = "false";
       }
+      maxAudioBitrate = this.properties.maxAudioBitrate != null ? this.properties.maxAudioBitrate : "40";
     }
     if ((width == null) || width === 0 || (height == null) || height === 0) {
       width = DefaultWidth;
@@ -315,7 +316,7 @@ TBPublisher = (function() {
     position = getPosition(this.domId);
     TBUpdateObjects();
     OT.getHelper().eventing(this);
-    Cordova.exec(TBSuccess, TBError, OTPlugin, "initPublisher", [name, position.top, position.left, width, height, zIndex, publishAudio, publishVideo, cameraName, ratios.widthRatio, ratios.heightRatio]);
+    Cordova.exec(TBSuccess, TBError, OTPlugin, "initPublisher", [name, position.top, position.left, width, height, zIndex, publishAudio, publishVideo, cameraName, ratios.widthRatio, ratios.heightRatio, maxAudioBitrate]);
     Cordova.exec(this.eventReceived, TBSuccess, OTPlugin, "addEvent", ["publisherEvents"]);
   }
 
@@ -2570,7 +2571,7 @@ OTHelpers.roundFloat = function(value, places) {
     };
 
   };
-  
+
 })(window, window.OTHelpers);
 
 /*jshint browser:true, smarttabs:true*/
@@ -2784,7 +2785,7 @@ OTHelpers.observeStyleChanges = function(element, stylesToObserve, onChange) {
 
             OTHelpers.forEach(stylesToObserve, function(style) {
                 if(isHidden && (style == 'width' || style == 'height')) return;
-                
+
                 var newValue = getStyle(style);
 
                 if (newValue !== oldStyles[style]) {
@@ -2926,7 +2927,7 @@ OTHelpers.observeNodeOrChildNodeRemoval = function(element, onChange) {
     };
 
     document.body.appendChild(domElement);
-    
+
     if(OTHelpers.browserVersion().iframeNeedsLoad) {
       OTHelpers.on(domElement, 'load', wrappedCallback);
     } else {
@@ -2943,11 +2944,11 @@ OTHelpers.observeNodeOrChildNodeRemoval = function(element, onChange) {
     this.element = domElement;
 
   };
-  
+
 })(window, window.OTHelpers);
 
 /*
- * getComputedStyle from 
+ * getComputedStyle from
  * https://github.com/jonathantneal/Polyfills-for-IE8/blob/master/getComputedStyle.js
 
 // tb_require('../helpers.js')
@@ -3217,7 +3218,7 @@ OTHelpers.centerElement = function(element, width, height) {
       }
 
       if (!defaultDisplays[element.ownerDocument]) defaultDisplays[element.ownerDocument] = {};
-    
+
       // We need to know what display value to use for this node. The easiest way
       // is to actually create a node and read it out.
       var testNode = element.ownerDocument.createElement(element.nodeName),

--- a/www/opentok.js
+++ b/www/opentok.js
@@ -281,7 +281,7 @@ TBPublisher = (function() {
     this.streamCreated = __bind(this.streamCreated, this);
     this.eventReceived = __bind(this.eventReceived, this);
     this.setSession = __bind(this.setSession, this);
-    var cameraName, height, name, position, publishAudio, publishVideo, ratios, width, zIndex, _ref, _ref1, _ref2, _ref3, maxAudioBitrate;
+    var cameraName, defaultAudioBitrate, height, maxAudioBitrate, name, position, publishAudio, publishVideo, ratios, width, zIndex, _ref, _ref1, _ref2, _ref3, _ref4;
     this.sanitizeInputs(one, two, three);
     pdebug("creating publisher", {});
     position = getPosition(this.domId);
@@ -291,18 +291,19 @@ TBPublisher = (function() {
     cameraName = "front";
     zIndex = TBGetZIndex(document.getElementById(this.domId));
     ratios = TBGetScreenRatios();
+    defaultAudioBitrate = "40";
     if (this.properties != null) {
       width = (_ref = this.properties.width) != null ? _ref : position.width;
       height = (_ref1 = this.properties.height) != null ? _ref1 : position.height;
       name = (_ref2 = this.properties.name) != null ? _ref2 : "";
       cameraName = (_ref3 = this.properties.cameraName) != null ? _ref3 : "front";
+      maxAudioBitrate = (_ref4 = this.properties.maxAudioBitrate) != null ? _ref4 : defaultAudioBitrate;
       if ((this.properties.publishAudio != null) && this.properties.publishAudio === false) {
         publishAudio = "false";
       }
       if ((this.properties.publishVideo != null) && this.properties.publishVideo === false) {
         publishVideo = "false";
       }
-      maxAudioBitrate = this.properties.maxAudioBitrate != null ? this.properties.maxAudioBitrate : "40";
     }
     if ((width == null) || width === 0 || (height == null) || height === 0) {
       width = DefaultWidth;
@@ -2571,7 +2572,7 @@ OTHelpers.roundFloat = function(value, places) {
     };
 
   };
-
+  
 })(window, window.OTHelpers);
 
 /*jshint browser:true, smarttabs:true*/
@@ -2785,7 +2786,7 @@ OTHelpers.observeStyleChanges = function(element, stylesToObserve, onChange) {
 
             OTHelpers.forEach(stylesToObserve, function(style) {
                 if(isHidden && (style == 'width' || style == 'height')) return;
-
+                
                 var newValue = getStyle(style);
 
                 if (newValue !== oldStyles[style]) {
@@ -2927,7 +2928,7 @@ OTHelpers.observeNodeOrChildNodeRemoval = function(element, onChange) {
     };
 
     document.body.appendChild(domElement);
-
+    
     if(OTHelpers.browserVersion().iframeNeedsLoad) {
       OTHelpers.on(domElement, 'load', wrappedCallback);
     } else {
@@ -2944,11 +2945,11 @@ OTHelpers.observeNodeOrChildNodeRemoval = function(element, onChange) {
     this.element = domElement;
 
   };
-
+  
 })(window, window.OTHelpers);
 
 /*
- * getComputedStyle from
+ * getComputedStyle from 
  * https://github.com/jonathantneal/Polyfills-for-IE8/blob/master/getComputedStyle.js
 
 // tb_require('../helpers.js')
@@ -3218,7 +3219,7 @@ OTHelpers.centerElement = function(element, width, height) {
       }
 
       if (!defaultDisplays[element.ownerDocument]) defaultDisplays[element.ownerDocument] = {};
-
+    
       // We need to know what display value to use for this node. The easiest way
       // is to actually create a node and read it out.
       var testNode = element.ownerDocument.createElement(element.nodeName),


### PR DESCRIPTION
## Changes

Added functionality to manually set audio bitrate from front end on mobile
#### This included:
- Updating publisher coffee script to read and set audio bitrate property
- Pass in audio bitrate property to the cordova exec native script
- Declaring the audio bit rate function in the openTok plugin header
- Setting the publisher's maxAudioBitrate in the opentok plug implementation file 
## Testing
- Add the branch name to the clone in the Dockerfile: `https://github.com/ElephantVentures/cordova-plugin-opentok.git --branch  feature/set-bitrate`
- Run `npm run build-app-qa debug`
- [ ] Verify that you can set the audio bitrate on mobile 
