### PR TITLE
feature/disable hdmi audio

### DIFF
--- a/src/ios/OpenTokPlugin.m
+++ b/src/ios/OpenTokPlugin.m
@@ -24,11 +24,11 @@
 #pragma mark Cordova Methods
 - (void) pluginInitialize{
     callbackList = [[NSMutableDictionary alloc] init];
-    _audioDevice = [[OpenTokPluginAudioDevice alloc] init];
+//    _audioDevice = [[OpenTokPluginAudioDevice alloc] init];
     // Uncomment code below to enable logging for
     // AVAudioSession via Opentok signaling
 //    [_audioDevice setDelegate: self];
-    [OTAudioDeviceManager setAudioDevice: _audioDevice];
+//    [OTAudioDeviceManager setAudioDevice: _audioDevice];
 }
 - (void)addEvent:(CDVInvokedUrlCommand*)command{
     NSString* event = [command.arguments objectAtIndex:0];


### PR DESCRIPTION
## Changes
- Disable the code for handling hdmi audio

#### This includes:
- Unregistering the `OpenTokPluginAudioDevice` (handles the HDMI audio and all other outputs) as an audio device for the `OTAudioDeviceManager`

## Testing
1. Add the branch name to the clone in the Dockerfile: `https://github.com/ElephantVentures/cordova-plugin-opentok.git --branch  feature/disable-hdmi-audio`
2. Run `npm run build-app-qa debug`
3. [x] Do regression testing. Be sure to test multiple combination of setups:
  - Built-in speakers
  - HDMI
  - Headphones/Earphones
  - HDMI + Headphones/Earphones